### PR TITLE
[Autofix][warning] Alert #65: Poorly documented large function

### DIFF
--- a/XEngine_Source/XEngine_APPService/XEngine_AuthorizeService/XEngine_AuthorizeService.cpp
+++ b/XEngine_Source/XEngine_APPService/XEngine_AuthorizeService/XEngine_AuthorizeService.cpp
@@ -126,14 +126,31 @@ LONG WINAPI Coredump_ExceptionFilter(EXCEPTION_POINTERS* pExceptionPointers)
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
+/**
+ * @brief Authorize service process entry point.
+ *
+ * This function coordinates the full service lifecycle:
+ * 1) platform/runtime bootstrap (network stack, locale, crash handler),
+ * 2) configuration and parameter handling,
+ * 3) initialization of logging, protocol stacks, and worker components,
+ * 4) service run loop and signal-controlled shutdown,
+ * 5) orderly release of all allocated resources.
+ *
+ * Notes:
+ * - Platform-specific startup paths are guarded by compile-time macros.
+ * - Error paths return early to avoid continuing in a partially initialized state.
+ */
 int main(int argc, char** argv)
 {
 #ifdef _WINDOWS
+	// Initialize Winsock for all subsequent socket-based modules.
 	WSADATA st_WSAData;
 	WSAStartup(MAKEWORD(2, 2), &st_WSAData);
 
+	// Register unhandled exception filter to generate a dump file on crash.
 	SetUnhandledExceptionFilter(Coredump_ExceptionFilter);
 #ifndef _DEBUG
+	// Ensure UTF-8 locale in release builds for consistent text processing/logging.
 	if (setlocale(LC_ALL, ".UTF8") == NULL)
 	{
 		fprintf(stderr, "Error setting locale.\n");


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#65](https://github.com/libxengine/XEngine_Authorize/security/code-scanning/65) |
| **安全级别** | warning |
| **规则名称** | Poorly documented large function |
| **问题文件** | `XEngine_Source/XEngine_APPService/XEngine_AuthorizeService/XEngine_AuthorizeService.cpp` 第 129 行 |
| **CWE 分类** |  |
| **规则标签** | documentation, maintainability, non-attributable, statistical |

---

### 🔍 问题说明

# Poorly documented large function
This rule finds large functions that have too few comment lines. Documentation becomes more important as a function becomes more complex, and a lack of documentation makes it harder to maintain.


## Recommendation
Add comments to document the purpose of the function. Large, complex functions in particular require detailed documentation, not only because they are harder to understand, but the process of documentation may reveal that the function could be split into smaller, more cohesive functions.


## References
* [C++ Programming, Coding style conventions](http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments)
* [Wikipedia: Need for comments](http://en.wikipedia.org/wiki/Comment_%28computer_progr

---

### 🤖 AI 修复思路

Best fix approach: add high-value, section-level comments inside `main` (and an overall function header comment) to document purpose and major phases, without altering behavior. This directly addresses the “poorly documented large function” finding and improves maintainability immediately.

Single best way here (without changing functionality): in `XEngine_Source/XEngine_APPService/XEngine_AuthorizeService/XEngine_AuthorizeService.cpp`, add a concise doc block immediately above `main` describing what it coordinates, and add inline phase comments at key blocks (platform/network init, crash handling, locale, argument/config parsing, module initialization, run loop, cleanup). Since only a partial snippet is provided, we can safely apply a guaranteed edit near line 129 by inserting a function-level documentation block above `main` and annotating the visible Windows-init section. No new methods/imports/dependencies are needed.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。